### PR TITLE
Update install_docker.sh

### DIFF
--- a/install_docker.sh
+++ b/install_docker.sh
@@ -3,7 +3,7 @@
 sudo apt-get remove docker docker-engine docker.io containerd runc
 
 sudo apt-get update
-sudo apt-get install ca-certificates curl gnupg
+sudo apt-get install ca-certificates curl gnupg -y
 
 sudo install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
@@ -15,7 +15,7 @@ echo \
 sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 sudo apt-get update
-sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 sudo docker run --rm hello-world
 
 echo done


### PR DESCRIPTION
This pull request updates the `install_docker.sh` script to streamline the Docker installation process by adding automatic confirmation for package installations. The changes ensure that the script can run without requiring manual user input during the installation steps.

Improvements to the installation process:

* [`install_docker.sh`](diffhunk://#diff-276c80f11b0991c6d9e806e184774c2967d4cfb3234a743565a83627d1d50a49L6-R6): Added the `-y` flag to `sudo apt-get install` commands to automatically confirm package installations for `ca-certificates`, `curl`, `gnupg`, and Docker-related packages. This change simplifies the script execution by removing the need for manual confirmation. [[1]](diffhunk://#diff-276c80f11b0991c6d9e806e184774c2967d4cfb3234a743565a83627d1d50a49L6-R6) [[2]](diffhunk://#diff-276c80f11b0991c6d9e806e184774c2967d4cfb3234a743565a83627d1d50a49L18-R18)